### PR TITLE
Fixes drag n drop images to upload. Adds copy/paste image upload.

### DIFF
--- a/background.js
+++ b/background.js
@@ -809,6 +809,9 @@ var background = {
 				case "getPaginatedObjectStore":
 					database.getPaginatedObjectStore(request.page, request.type, sendResponse);
 					return true;
+				case "AsyncUpload":
+					// handled in transloader.js
+					return true;
 					
 				default:
 					console.log("Error in request listener - undefined parameter?", request);

--- a/background.js
+++ b/background.js
@@ -809,6 +809,7 @@ var background = {
 				case "getPaginatedObjectStore":
 					database.getPaginatedObjectStore(request.page, request.type, sendResponse);
 					return true;
+				case 'backGroundUrltoBlob':
 				case "AsyncUpload":
 					// handled in transloader.js
 					return true;

--- a/src/css/lovelinks.css
+++ b/src/css/lovelinks.css
@@ -53,7 +53,7 @@ body.snow, body.hup_hup {
 }
 
 .quickpost-body {
-	ackground-color: #EDB4E2 !important; color: #0D030B !important;
+	background-color: #EDB4E2 !important; color: #0D030B !important;
 }
 
 .quickpost-canvas {

--- a/src/js/allPages.js
+++ b/src/js/allPages.js
@@ -26,7 +26,7 @@ var allPages = {
 			}
 			
 			// text area when hitting ~ in topic
-			var textArea2 = document.getElementById("u0_59");
+			var textArea2 = document.getElementsByClassName('quickpost-body')[0].getElementsByTagName('textarea')[0]
 			if (textArea2  != undefined) {
 				textArea2.addEventListener('paste', (event) => {
 					var items = (event.clipboardData || event.originalEvent.clipboardData).items;
@@ -690,23 +690,23 @@ var allPages = {
 			fileReader.onload = function(event) {
 				arrayBuffer = event.target.result;
 
-				if (allPages.asyncUploadQueue.index >= allPages.asyncUploadQueue.total) {
-					// No need to show progress anymore - change type to 'basic' and update title
-					if (allPages.asyncUploadQueue.index > 1) {
-						chrome.runtime.sendMessage({ need: 'clear_progress_notify', title: 'Uploads complete' });
-					}
-					else {
-						chrome.runtime.sendMessage({ need: 'clear_progress_notify', title: 'Upload complete' });
-					}
-					allPages.asyncUploadQueue.clear();
-				} else {
-					chrome.runtime.sendMessage({ need: 'update_progress_notify', 
-						update: {						
-							title: 'Uploading: (' + allPages.asyncUploadQueue.index + '/' + allPages.asyncUploadQueue.total + ')',
-							progress: 0
-						}
-					});												
-				}
+				// if (allPages.asyncUploadQueue.index >= allPages.asyncUploadQueue.total) {
+				// 	// No need to show progress anymore - change type to 'basic' and update title
+				// 	if (allPages.asyncUploadQueue.index > 1) {
+				// 		chrome.runtime.sendMessage({ need: 'clear_progress_notify', title: 'Uploads complete' });
+				// 	}
+				// 	else {
+				// 		chrome.runtime.sendMessage({ need: 'clear_progress_notify', title: 'Upload complete' });
+				// 	}
+				// 	allPages.asyncUploadQueue.clear();
+				// } else {
+				// 	chrome.runtime.sendMessage({ need: 'update_progress_notify', 
+				// 		update: {						
+				// 			title: 'Uploading: (' + allPages.asyncUploadQueue.index + '/' + allPages.asyncUploadQueue.total + ')',
+				// 			progress: 0
+				// 		}
+				// 	});												
+				// }
 				// send to background script to upload without hitting CORS error
 				chrome.runtime.sendMessage({
 					type: 'AsyncUpload',
@@ -723,12 +723,12 @@ var allPages = {
 			fileReader.readAsArrayBuffer(file);		
 			//this.asyncUpload(this.asyncUploadQueue.next(), callback);
 			
-			chrome.runtime.sendMessage({ need: 'progress_notify',
-					data: {
-							title: 'Uploading: (' + this.asyncUploadQueue.index + '/' + this.asyncUploadQueue.total + ')',
-							progress: 0
-					}
-			});			
+			// chrome.runtime.sendMessage({ need: 'progress_notify',
+			// 		data: {
+			// 				title: 'Uploading: (' + this.asyncUploadQueue.index + '/' + this.asyncUploadQueue.total + ')',
+			// 				progress: 0
+			// 		}
+			// });			
 		}			
 	},
 

--- a/src/js/allPages.js
+++ b/src/js/allPages.js
@@ -26,21 +26,25 @@ var allPages = {
 			}
 			
 			// text area when hitting ~ in topic
-			var textArea2 = document.getElementsByClassName('quickpost-body')[0].getElementsByTagName('textarea')[0]
-			if (textArea2  != undefined) {
-				textArea2.addEventListener('paste', (event) => {
-					var items = (event.clipboardData || event.originalEvent.clipboardData).items;
-					for (index in items) {
-						var item = items[index];
-						if (item.kind === 'file') {
-							var blob = item.getAsFile();
-							allPages.asyncUploadHandler(blob, function (e){
-								allPages.insertIntoTextarea(e)
-							});
+			var quickpost = document.getElementsByClassName('quickpost-body')[0]
+			if (quickpost) {
+				var textArea2 = quickpost.getElementsByTagName('textarea')[0]
+				if (textArea2  != undefined) {
+					textArea2.addEventListener('paste', (event) => {
+						var items = (event.clipboardData || event.originalEvent.clipboardData).items;
+						for (index in items) {
+							var item = items[index];
+							if (item.kind === 'file') {
+								var blob = item.getAsFile();
+								allPages.asyncUploadHandler(blob, function (e){
+									allPages.insertIntoTextarea(e)
+								});
+							}
 						}
-					}
-				});
+					});
+				}
 			}
+			
 		},
 		
 		error_check : function() {

--- a/src/js/messageList.js
+++ b/src/js/messageList.js
@@ -317,10 +317,11 @@ var messageList = {
 			(document.getElementById("message") || document.getElementsByTagName("textarea")[0]).addEventListener("drop", function (e)
 			{
 				new FileReader;
-				for (var t = 0, s = e.dataTransfer.files.length; t < s; t++) allPages.asyncUploadHandler(e.dataTransfer.files[t], function (e)
-				{
-					allPages.insertIntoTextarea(e)
-				});
+				for (var t = 0, s = e.dataTransfer.files.length; t < s; t++) {
+					allPages.asyncUploadHandler(e.dataTransfer.files[t], function (e) {
+						allPages.insertIntoTextarea(e)
+					});
+				} 
 				e.preventDefault()
 			})
 		},

--- a/src/js/messageList.js
+++ b/src/js/messageList.js
@@ -317,11 +317,33 @@ var messageList = {
 			(document.getElementById("message") || document.getElementsByTagName("textarea")[0]).addEventListener("drop", function (e)
 			{
 				new FileReader;
-				for (var t = 0, s = e.dataTransfer.files.length; t < s; t++) {
-					allPages.asyncUploadHandler(e.dataTransfer.files[t], function (e) {
-						allPages.insertIntoTextarea(e)
-					});
-				} 
+				if (e.dataTransfer.files.length > 0) {
+					for (var t = 0, s = e.dataTransfer.files.length; t < s; t++) {
+						allPages.asyncUploadHandler(e.dataTransfer.files[t], function (e) {
+							allPages.insertIntoTextarea(e)
+						});
+					}
+				} else {
+					for(var k = 0; k < e.dataTransfer.items.length; k++) {
+						var item = e.dataTransfer.items[k];
+						if (item.type == "text/uri-list") {
+							item.getAsString(function(data) {
+								chrome.runtime.sendMessage({
+									type: 'backGroundUrltoBlob',
+									need: 'backGroundUrltoBlob',
+									url: data,
+								}, function(response) {
+									var dataview = new DataView(Uint8Array.from(Object.values(response.fileBytes)).buffer);
+									var file = new File([dataview], response.fileType)
+									allPages.asyncUploadHandler(file, function (e) {
+										allPages.insertIntoTextarea(e)
+									});
+								})
+							});
+						}
+						
+					}
+				}
 				e.preventDefault()
 			})
 		},

--- a/src/js/transloader.js
+++ b/src/js/transloader.js
@@ -461,5 +461,25 @@ chrome.runtime.onMessage.addListener(function(message, sender, handler) {
 			}
 		}
 		return true
+	} else if (message && message.type == 'backGroundUrltoBlob') {
+		fetch(message.url)
+		.then(function(response) {
+			return response.blob()
+		})
+		.then(function(blob) {
+			var arrayBuffer;
+			var fileType = blob.type
+			var fileReader = new FileReader();
+			fileReader.onload = function(event) {
+				var arrayBuffer = event.target.result;
+				var bytes = new Uint8Array(arrayBuffer)
+				handler( {
+					fileBytes: bytes,
+					fileType: fileType
+				})
+			}
+			fileReader.readAsArrayBuffer(blob);
+		});
+		return true;
 	}
 });

--- a/src/json/defaultconfig.json
+++ b/src/json/defaultconfig.json
@@ -14,6 +14,7 @@
 	"hide_gs":false,
 	"zebra_tables":false,
 	"zebra_tables_color":"D7DEE8",
+	"image_paste":true,
 	"error_check":true,
 	"force_https":false,
 	"sys_notifications":true,


### PR DESCRIPTION
Uploading images by dragging files to the message textarea has been broken in chrome due to chrome adding stricter CORS prevention at some point.  These changes allow the uploading to be done by transloader.js in the background avoiding a CORS issue.  This also enables resizing images uploaded this way if resizing is enabled.  
I also added some copy/paste image functionality.  It seems to work if you copy form a webpage or discord, but not an image file on your computer.  
